### PR TITLE
Fix logo link to use relative path instead of absolute URL

### DIFF
--- a/themes/blank/layouts/partials/header.html
+++ b/themes/blank/layouts/partials/header.html
@@ -5,10 +5,10 @@
     <!-- Sliding background indicator -->
     <div class="nav-indicator"></div>
 
-    <a class="logo relative z-10 p-1" href="{{ .Site.BaseURL }}" data-nav-item>
+    <a class="logo relative z-10 p-1" href="/" data-nav-item>
       <img
         class="w-7 min-w-7 rounded-full border border-white"
-        src="{{ .Site.BaseURL }}img/avatar.png"
+        src="/img/avatar.png"
       />
       <!-- {{ .Site.Title }} -->
     </a>
@@ -32,3 +32,4 @@
 
   {{ partial "theme-switcher.html" }}
 </header>
+

--- a/themes/blank/layouts/partials/sidebar.html
+++ b/themes/blank/layouts/partials/sidebar.html
@@ -5,10 +5,10 @@
   <div class="flex flex-col h-full">
     <!-- Logo -->
     <div class="flex items-center gap-3 mb-8">
-      <a class="logo" href="{{ .Site.BaseURL }}">
+      <a class="logo" href="/">
         <img
           class="w-9 min-w-9 rounded-full border border-white"
-          src="{{ .Site.BaseURL }}img/avatar.png"
+          src="/img/avatar.png"
         />
       </a>
     </div>
@@ -39,3 +39,4 @@
     </div>
   </div>
 </aside>
+


### PR DESCRIPTION
## Problem\nThe logotype was linking to the hardcoded absolute URL  instead of using a relative path. This caused navigation issues when accessing the site via the Railway domain (), making blog posts and other generated pages inaccessible.\n\n## Solution\nChanged the logo links in both  and  from  to  (relative path), and updated the avatar image source from  to .\n\nThis ensures the logo always links to the home page of whatever domain is being used, whether it's the production domain, Railway domain, or localhost during development.\n\n## Files Changed\n- \n-